### PR TITLE
fix python unknown option -p

### DIFF
--- a/support/2.0/Ubuntu/MW4_Install.sh
+++ b/support/2.0/Ubuntu/MW4_Install.sh
@@ -95,7 +95,7 @@ echo installing mountwizzard4 - takes some time
 echo --------------------------------------------------------
 
 echo checking system packages, should be no mw4 in >> install.log  2>&1
-python -p pip list >> install.log 2>&1
+python -m pip list >> install.log 2>&1
 
 source ./venv/bin/activate venv >> install.log 2>&1
 python -m pip install pip --upgrade >> install.log 2>&1
@@ -104,7 +104,7 @@ python -m pip install wheel --upgrade >> install.log 2>&1
 python -m pip install mountwizzard4 --upgrade --no-cache-dir >> install.log 2>&1
 
 echo checking venv packages, mw4 should be present >> install.log  2>&1
-python -p pip list >> install.log 2>&1
+python -m pip list >> install.log 2>&1
 
 echo
 echo --------------------------------------------------------


### PR DESCRIPTION
Hi Michael, Hans here, a small Ubuntu installer fix :
```
+ python -p pip list
Unknown option: -p
usage: python [option] ... [-c cmd | -m mod | file | -] [arg] ...
Try `python -h' for more information.
```
I did not see this earlier because I just wrote my own commands ;-)