### PR TITLE
Fix ASCOM driver selection crashing in DevicePopup

### DIFF
--- a/src/mw4/base/ascomClass.py
+++ b/src/mw4/base/ascomClass.py
@@ -69,7 +69,10 @@ class AscomClass(AlpacaAscomCommon):
         self.workerRunnerCoreLoop = Worker(self.runnerCoreLoop)
         self.threadPool.start(self.workerRunnerCoreLoop)
 
-    def selectAscomDriver(self, deviceName: str, deviceType: str) -> str:
+    @classmethod
+    def selectAscomDriver(cls, deviceName: str, deviceType: str) -> str:
+        # Runs the ASCOM chooser via a logger only, so it can be called without
+        # constructing an AscomClass instance (see DevicePopup.selectAscomDriver).
         # Arguments are passed as a JSON payload to avoid code injection via
         # f-string interpolation into the subprocess script. (SEC-1)
         script = (
@@ -88,7 +91,7 @@ class AscomClass(AlpacaAscomCommon):
                 creationflags=0x08000000,  # CREATE_NO_WINDOW
             ).strip()
         except subprocess.CalledProcessError as e:
-            self.log.critical(f"ASCOM Chooser subprocess error: {e}")
+            cls.log.critical(f"ASCOM Chooser subprocess error: {e}")
             return deviceName
-        self.log.debug(f"ASCOM Chooser result: [{result}]")
+        cls.log.debug(f"ASCOM Chooser result: [{result}]")
         return result if result else deviceName

--- a/src/mw4/gui/extWindows/devicePopupW.py
+++ b/src/mw4/gui/extWindows/devicePopupW.py
@@ -310,8 +310,8 @@ class DevicePopup(MWidget):
         self.platesolvers[framework]["indexPath"].setText(str(indexFolderPath))
 
     def selectAscomDriver(self) -> None:
-        ascom = AscomClass(parent=self.parent)
-        deviceName = ascom.selectAscomDriver(self.ui.ascomDevice.text(), self.deviceType)
+        deviceType = self.app.dReg[self.device].instance.DEVICE_TYPE
+        deviceName = AscomClass.selectAscomDriver(self.ui.ascomDevice.text(), deviceType)
         self.ui.ascomDevice.setText(deviceName)
 
     def selectBoltwoodPath(self) -> None:


### PR DESCRIPTION
Fixes #413.

`DevicePopup.selectAscomDriver` constructed `AscomClass(parent=self.parent)`, but `self.parent` is Qt's bound `QObject.parent` method — `AlpacaAscomCommon.__init__` then evaluates `parent.data` on it and raises `AttributeError`. It also referenced `self.deviceType`, which `DevicePopup` does not define (only `self.device`), so it would crash on the next line regardless. Net effect: the ASCOM chooser never opens, so no ASCOM device (camera, focuser, filter wheel, weather, dome, …) can be selected.

**Change**
- `AscomClass.selectAscomDriver` only uses the class logger, so it is now a `@classmethod` and is called without constructing a driver instance.
- The device type is resolved from the device registry (`self.app.dReg[self.device].instance.DEVICE_TYPE`), matching the existing `discoverDevices()` code path.

**Testing**
- Windows 11 / Python 3.13.12 / PySide6 6.11.1: the ASCOM Chooser opens and a ZWO ASI camera (`ASCOM.ASICamera2.Camera`) selects and connects.
- `py_compile` clean; no other call sites construct `AscomClass` for the chooser.
